### PR TITLE
Drop python2 support and make it work with python3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [1.0] - 2019-05-06
+
+### Breaking changes
+- Drop support for python 2
+
+### Added
+- Support for python 3
+
+### Fixed
+- Code formatting

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ when compared to latex.
 Install
 =======
 
-    pip2 install lax
+    pip install --user lax
 
 That is all.
 
@@ -24,13 +24,12 @@ With basic operations:
 
     [tau@sigma ~]$ lax -c 'x * (2 - y) * yz'
     x\cdot \left(2-y\right)\cdot yz
-    [tau@sigma ~]$ 
-      
+    [tau@sigma ~]$
+
 With roots and fractions:
 
     [tau@sigma ~]$ lax -c '2 ^ x/(2 - y)'
     \sqrt[2]{\left(\frac{x}{2-y}\right)}
-        
 
 Notice that to use the root you use ^:
 
@@ -60,7 +59,7 @@ With functions:
 
     [tau@sigma ~]$ lax -c 'xyz^(alpha(x-2))'
     \sqrt[xyz]{alpha(x-2)}
-    [tau@sigma ~]$ 
+    [tau@sigma ~]$
 
 Notice that if you want to omit multiplication sign you can do:
 
@@ -86,5 +85,3 @@ A really convoluted example:
 
     [tau@sigma ~]$ lax -c 'x * (x-3) (f(x-3) - 2) (x ** (x-3/(x-2)))'
     x\cdot \left(x-3\right)\left(f\left(x-3\right)-2\right)\left({x}^{\left(x-\frac{3}{x-2}\right)}\right)
-
-

--- a/escs.sh
+++ b/escs.sh
@@ -1,38 +1,39 @@
+#!/usr/bin/env bash
+
 ##############################################################################
 # clone lax repository.
 
-cd ~/projects
+cd ~/projects || exit
 git clone git@github.com:iogf/lax.git lax-code
 
 # push lax.
-cd ~/projects/lax-code
+cd ~/projects/lax-code || exit
 git status
-git add *
-git commit -a 
+git add -- *
+git commit -a
 git push
 
 # it installs lax.
-cd ~/projects/lax-code
+cd ~/projects/lax-code || exit
 sudo bash -i
 python2 setup.py install
 rm -fr build
 exit
 ##############################################################################
 # create, development, branch, lax.
-cd /home/tau/projects/lax-code/
+cd ~/projects/lax-code/ || exit
 git branch -a
 git checkout -b development
 git push --set-upstream origin development
 ##############################################################################
 # merge development into master.
-cd /home/tau/projects/lax-code/
+cd ~/projects/lax-code/ || exit
 git checkout master
 git merge development
 git push
 git checkout development
 ##############################################################################
 
-cd ~/projects/lax-code
+cd ~/projects/lax-code || exit
 python setup.py sdist register upload
 rm -fr dist
-

--- a/lax
+++ b/lax
@@ -1,15 +1,18 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from liblax.parser import run
     from optparse import OptionParser
-    
-    parser   = OptionParser()
-    parser.add_option("-c", "--code", action='store', dest="code", help="Example: lax - c 'x ** 2 - 1'")
+    import sys
+
+    parser = OptionParser()
+    parser.add_option(
+        "-c", "--code", action="store", dest="code", help="Example: lax -c 'x ** 2 - 1'"
+    )
     (opt, args) = parser.parse_args()
-    
-    print run(opt.code)
-    
 
+    if opt.code is None:
+        parser.print_help()
+        sys.exit("Error: no code provided!")
 
-
+    print(run(opt.code))

--- a/liblax/core.py
+++ b/liblax/core.py
@@ -1,7 +1,6 @@
-
-
 FMT0 = lambda data: data
-FMT1 = lambda data: '\\left(%s\\right)' % data
+FMT1 = lambda data: "\\left(%s\\right)" % data
+
 
 class Function(object):
     def __call__(self, exp):
@@ -9,10 +8,11 @@ class Function(object):
 
     def __init__(self, name, exp):
         self.name = name
-        self.exp  = exp
+        self.exp = exp
 
     def __str__(self, op=None):
-        return '%s\\left(%s\\right)' % (self.name, self.exp.__str__(self))
+        return "%s\\left(%s\\right)" % (self.name, self.exp.__str__(self))
+
 
 class Chk(object):
     def __call__(self, exp):
@@ -48,6 +48,12 @@ class Chk(object):
     def __rdiv__(self, other):
         return Div(other, self)
 
+    def __truediv__(self, other):
+        return Div(self, other)
+
+    def __rtruediv__(self, other):
+        return Div(other, self)
+
     def __pow__(self, other):
         return Exp(other, self)
 
@@ -60,182 +66,161 @@ class Chk(object):
     def __xor__(self, other):
         return Pow(other, self)
 
+
 class Num(Chk):
     def __init__(self, val):
         Chk.__init__(self, val)
 
+
 class Block(object):
     def __call__(self, exp):
-        return Block(self, exp) 
+        return Block(self, exp)
 
     def __init__(self, exp0, exp1):
         self.exp0 = exp0
-        self.exp1  = exp1
+        self.exp1 = exp1
 
     def __str__(self, op=None):
-        tmp = '\\left(%s\\right)' 
+        tmp = "\\left(%s\\right)"
         lhs = self.exp0.__str__(self)
         lhs = tmp % lhs if not isinstance(self.exp0, Block) else lhs
         rhs = self.exp1.__str__(self)
         rhs = tmp % rhs if not isinstance(self.exp1, Block) else rhs
-        return '%s%s' % (lhs, rhs)
+        return "%s%s" % (lhs, rhs)
+
 
 class Op(Chk):
     def __call__(self, exp):
         return Block(self, exp)
 
     def __init__(self, lhs, rhs, arg_map, op_map, default_arg_map, default_op_map):
-        self.lhs              = lhs
-        self.rhs              = rhs
-        self.arg_map          = arg_map
-        self.op_map           = op_map
-        self.default_arg_map  = default_arg_map
-        self.default_op_map   = default_op_map
+        self.lhs = lhs
+        self.rhs = rhs
+        self.arg_map = arg_map
+        self.op_map = op_map
+        self.default_arg_map = default_arg_map
+        self.default_op_map = default_op_map
 
     def __str__(self, op=None):
         FMT_ARG = self.arg_map.get(op.__class__, self.default_arg_map)
-        FMT_OP  = self.op_map.get((self.lhs.__class__, self.rhs.__class__), self.default_op_map)
-        data    = FMT_OP(self.lhs.__str__(self), self.rhs.__str__(self))
+        FMT_OP = self.op_map.get(
+            (self.lhs.__class__, self.rhs.__class__), self.default_op_map
+        )
+        data = FMT_OP(self.lhs.__str__(self), self.rhs.__str__(self))
 
         return FMT_ARG(data)
+
 
 class Sum(Op):
     def __init__(self, lhs, rhs):
         SUM_ARG_MAP = {
-                    Chk: FMT0,
-                    Div: FMT0,
-                    Sum: FMT0,
-                    Sub: FMT0,
-                    Mul: FMT1,
-                    Pow: FMT1,
-                    Exp: FMT1,
-              }
-
-        SUM_OP_MAP = {
-                
+            Chk: FMT0,
+            Div: FMT0,
+            Sum: FMT0,
+            Sub: FMT0,
+            Mul: FMT1,
+            Pow: FMT1,
+            Exp: FMT1,
         }
 
-        DEFAULT_SUM_OP_MAP = lambda rhs, lhs: '%s+%s' % (rhs, lhs)
+        SUM_OP_MAP = {}
 
-        Op.__init__(self, lhs, rhs, SUM_ARG_MAP, SUM_OP_MAP, FMT0, 
-                    DEFAULT_SUM_OP_MAP)
+        DEFAULT_SUM_OP_MAP = lambda rhs, lhs: "%s+%s" % (rhs, lhs)
+
+        Op.__init__(self, lhs, rhs, SUM_ARG_MAP, SUM_OP_MAP, FMT0, DEFAULT_SUM_OP_MAP)
 
 
 class Sub(Op):
     def __init__(self, lhs, rhs):
         SUB_ARG_MAP = {
-                Chk: FMT0,
-                Div: FMT0,
-                Sum: FMT0,
-                Sub: FMT0,
-                Mul: FMT1,
-                Pow: FMT1,
-                Exp: FMT1,
-              }
-
-        SUB_OP_MAP = {
-        
+            Chk: FMT0,
+            Div: FMT0,
+            Sum: FMT0,
+            Sub: FMT0,
+            Mul: FMT1,
+            Pow: FMT1,
+            Exp: FMT1,
         }
 
-        DEFAULT_SUB_OP_MAP = lambda rhs, lhs: '%s-%s' % (rhs, lhs)
+        SUB_OP_MAP = {}
 
-        Op.__init__(self, lhs, rhs, SUB_ARG_MAP, SUB_OP_MAP, FMT0, 
-                    DEFAULT_SUB_OP_MAP)
+        DEFAULT_SUB_OP_MAP = lambda rhs, lhs: "%s-%s" % (rhs, lhs)
 
+        Op.__init__(self, lhs, rhs, SUB_ARG_MAP, SUB_OP_MAP, FMT0, DEFAULT_SUB_OP_MAP)
 
 
 class Mul(Op):
     def __init__(self, lhs, rhs):
 
         MUL_ARG_MAP = {
-                Chk: FMT0, 
-                Div: FMT0, 
-                Sum: FMT0,
-                Sub: FMT0,
-                Mul: FMT0,
-                Pow: FMT1,
-                Exp: FMT1,
-              }
-        
-        MUL_OP_MAP = {
-
+            Chk: FMT0,
+            Div: FMT0,
+            Sum: FMT0,
+            Sub: FMT0,
+            Mul: FMT0,
+            Pow: FMT1,
+            Exp: FMT1,
         }
 
-        DEFAULT_MUL_OP_MAP = lambda rhs, lhs: '%s\cdot %s' % (rhs, lhs)
+        MUL_OP_MAP = {}
 
-        Op.__init__(self, lhs, rhs, MUL_ARG_MAP, MUL_OP_MAP, FMT0, 
-                    DEFAULT_MUL_OP_MAP)
+        DEFAULT_MUL_OP_MAP = lambda rhs, lhs: "%s\cdot %s" % (rhs, lhs)
+
+        Op.__init__(self, lhs, rhs, MUL_ARG_MAP, MUL_OP_MAP, FMT0, DEFAULT_MUL_OP_MAP)
 
 
 class Div(Op):
     def __init__(self, lhs, rhs):
         DIV_ARG_MAP = {
-                Chk: FMT0,
-                Div: FMT0,
-                Sum: FMT0,
-                Sub: FMT0,
-                Mul: FMT0,
-                Pow: FMT1,
-                Exp: FMT1,
-
-              }
-
-        DIV_OP_MAP = {
-
+            Chk: FMT0,
+            Div: FMT0,
+            Sum: FMT0,
+            Sub: FMT0,
+            Mul: FMT0,
+            Pow: FMT1,
+            Exp: FMT1,
         }
 
+        DIV_OP_MAP = {}
 
-        DEFAULT_DIV_OP_MAP = lambda rhs, lhs: '\\frac{%s}{%s}' % (rhs, lhs)
+        DEFAULT_DIV_OP_MAP = lambda rhs, lhs: "\\frac{%s}{%s}" % (rhs, lhs)
 
-        Op.__init__(self, lhs, rhs, DIV_ARG_MAP, DIV_OP_MAP, FMT0, 
-                    DEFAULT_DIV_OP_MAP)
+        Op.__init__(self, lhs, rhs, DIV_ARG_MAP, DIV_OP_MAP, FMT0, DEFAULT_DIV_OP_MAP)
 
 
 class Pow(Op):
     def __init__(self, lhs, rhs):
         POW_ARG_MAP = {
-                Chk: FMT0,
-                Div: FMT0,
-                Sum: FMT0,
-                Sub: FMT0,
-                Mul: FMT0,
-                Pow: FMT0,
-                Exp: FMT1,
-              }
-
-        POW_OP_MAP = {
-
+            Chk: FMT0,
+            Div: FMT0,
+            Sum: FMT0,
+            Sub: FMT0,
+            Mul: FMT0,
+            Pow: FMT0,
+            Exp: FMT1,
         }
 
+        POW_OP_MAP = {}
 
-        DEFAULT_POW_OP_MAP = lambda lhs, rhs: '\\sqrt[%s]{%s}' % (rhs, lhs)
+        DEFAULT_POW_OP_MAP = lambda lhs, rhs: "\\sqrt[%s]{%s}" % (rhs, lhs)
 
-        Op.__init__(self, lhs, rhs, POW_ARG_MAP, POW_OP_MAP, FMT0, 
-                    DEFAULT_POW_OP_MAP)
+        Op.__init__(self, lhs, rhs, POW_ARG_MAP, POW_OP_MAP, FMT0, DEFAULT_POW_OP_MAP)
+
 
 class Exp(Op):
     def __init__(self, lhs, rhs):
-        DEFAULT_EXP_OP_MAP = lambda lhs, rhs: '{%s}^{%s}' % (rhs, lhs)
+        DEFAULT_EXP_OP_MAP = lambda lhs, rhs: "{%s}^{%s}" % (rhs, lhs)
 
         EXP_ARG_MAP = {
-                Chk: FMT0,
-                Div: FMT0,
-                Sum: FMT0,
-                Sub: FMT0,
-                Mul: FMT0,
-                Pow: FMT0,
-                Exp: FMT1,
-
-              }
-
-        EXP_OP_MAP = {
-
+            Chk: FMT0,
+            Div: FMT0,
+            Sum: FMT0,
+            Sub: FMT0,
+            Mul: FMT0,
+            Pow: FMT0,
+            Exp: FMT1,
         }
 
-        Op.__init__(self, lhs, rhs, EXP_ARG_MAP, EXP_OP_MAP, FMT0, 
-                    DEFAULT_EXP_OP_MAP)
+        EXP_OP_MAP = {}
 
-
-
-
-
+        Op.__init__(self, lhs, rhs, EXP_ARG_MAP, EXP_OP_MAP, FMT0, DEFAULT_EXP_OP_MAP)

--- a/liblax/parser.py
+++ b/liblax/parser.py
@@ -1,23 +1,29 @@
 from tokenize import generate_tokens as split
 from tokenize import NUMBER, NAME, STRING, OP, untokenize
-from StringIO import StringIO
+from io import StringIO
 from liblax.core import *
+
 
 def build(data):
     result = []
-    for num, val, _, _, _  in split(StringIO(data).readline):
-        if num == NUMBER: 
-            result.extend([(NAME, 'Num'), (OP, '('),
-            (STRING, str(val)), (OP, ')')])
-        elif num == NAME and not val.startswith('_'):
-            result.extend([(NAME, 'Chk'), 
-            (OP, '('), (OP, "'"),
-            (STRING, str(val)), (OP, "'"), (OP, ')')])
+    for num, val, _, _, _ in split(StringIO(data).readline):
+        if num == NUMBER:
+            result.extend([(NAME, "Num"), (OP, "("), (STRING, str(val)), (OP, ")")])
+        elif num == NAME and not val.startswith("_"):
+            result.extend(
+                [
+                    (NAME, "Chk"),
+                    (OP, "("),
+                    (OP, "'"),
+                    (STRING, str(val)),
+                    (OP, "'"),
+                    (OP, ")"),
+                ]
+            )
         else:
             result.append((num, val))
     return untokenize(result)
 
+
 def run(data):
     return eval(build(data))
-
-

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,15 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.core import setup
 
-setup(name="lax",
-      version="0.3",
-      packages=["liblax"],
-      scripts=['lax'],
-      author="Iury O. G. Figueiredo",
-      author_email="ioliveira@id.uff.br")
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+setup(
+    name="lax",
+    version="1.0",
+    description="A pythonic way of writing Latex",
+    packages=["liblax"],
+    scripts=["lax"],
+    author="Iury O. G. Figueiredo",
+    author_email="ioliveira@id.uff.br",
+    license="GPLv2",
+    url="https://github.com/iogf/lax",
+)


### PR DESCRIPTION
As mentioned here
https://github.com/iogf/lax/pull/2#issuecomment-406787989 dropping
support of python2 was intended.

* Change print function
* Change import of StringIO
* Doc: use pip install --user
* Remove whitespaces
* Reformat code
* Fix shell script (that seems to be internal notes more than a script
btw)
* Show help and error message if no input specified
* Add modifications by @jkempinger so all example code runs properly
* Add license and url in setup.py
* Bump version to 1.0

Closes #2. Fixes #1